### PR TITLE
add dummy libc++.so

### DIFF
--- a/ndk-android-21/usr/lib/libc++.so
+++ b/ndk-android-21/usr/lib/libc++.so
@@ -1,0 +1,1 @@
+INPUT(AS_NEEDED(-landroid))


### PR DESCRIPTION
It seems that a new version of clang (comes with xcode 11 on mac) always tries to link `libc++` even when it's not used. To workaround this issue we add a dummy of `libc++.so`