### PR TITLE
Add script to fix permissions to access NDK libs on MacOS Catalina

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,28 @@
 # swift-android-toolchain
-Build Swift for Android from Mac and Linux
 
+Build Swift for Android from Mac and Linux
 
 ## Installation
 
 ### For use within a specific project
 
 1. Add `swift-android-toolchain` as a git submodule
-2. Use `./path-to-submodule/swift-build.sh` whereever needed
+2. Use `./path-to-submodule/swift-build.sh` wherever needed
 
 [UIKit-cross-platform](https://github.com/flowkey/UIKit-cross-platform) uses this method (along with the Android Studio integration, below).
-
 
 ### For use globally from the command line
 
 1. Clone the repo
 1. Add the cloned destination to your `PATH` environment variable (e.g. in `~/.bash_profile` or equivalent)
 
-
 ## Usage
 
 ### In Android Studio / Gradle
 
-You probably want Gradle to compile your native sources automatically when building the android app. In order to archieve this, you have to create another `CMakeLists.txt` file and reference it from `app/build.gradle`.
+You probably want Gradle to compile your native sources automatically when building the android app. In order to achieve this, you have to create another `CMakeLists.txt` file and reference it from `app/build.gradle`.
 
-```
+```Gradle
 externalNativeBuild {
     cmake {
         version "3.16.2"
@@ -35,7 +33,7 @@ externalNativeBuild {
 
 In `android/app/src/CMakeLists.txt`, add the following code after the `cmake_minimum_required(VERSION x.y.z)` declaration.
 
-```
+```CMake
 # destination of project level CMakeLists.txt for building native sources
 get_filename_component(PROJECT_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../../ ABSOLUTE)
 
@@ -47,8 +45,8 @@ build_swift_project(
     PROJECT_DIRECTORY ${PROJECT_DIRECTORY}
 )
 ```
-Check out [getting-started](https://github.com/flowkey/UIKit-cross-platform/tree/master/samples/getting-started) for a working example.
 
+Check out [getting-started](https://github.com/flowkey/UIKit-cross-platform/tree/master/samples/getting-started) for a working example.
 
 ### From the command line
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Check out [getting-started](https://github.com/flowkey/UIKit-cross-platform/tree
 ANDROID_ABI="armeabi-v7a" CMAKE_BUILD_TYPE="Debug" swift-build.sh
 ```
 
+#### For users on MacOS Catalina (10.15.x)
+
+Since use a downloaded version of the Android NDK in this build, MacOS Catalina complains about security issues. Running the build might show you alerts for every library from the NDK that is invoked by the build script, asking to grant permissions.
+
+Running the [`fixCatalinaPermissions.sh`](fixCatalinaPermissions.sh) script, after setup, but before invoking the build, should resolve this issue.
+
 ## Credits
 
 Making this toolchain was only possible by standing on the shoulders of giants.

--- a/fixCatalinaPermissions.sh
+++ b/fixCatalinaPermissions.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## Fixes security/permission alerts that popup on MacOS Catalina (10.15.x)
+## due to executing libs from the NDK that we downloaded during setup.
+
+# common dependencies
+DEPENDENCIES=(clang clang++ as ld ld.gold *.dylib)
+
+# for each architecture
+for ARCHITECTURE in arm-linux-androideabi aarch64-linux-android x86_64-linux-android;
+do
+    for ARCH_DEPENDENCY in ranlib ar strip;
+    do
+        DEPENDENCIES+=( $ARCHITECTURE-$ARCH_DEPENDENCY )
+    done
+done
+
+for DEPENDENCY in ${DEPENDENCIES[@]};
+do
+ echo $DEPENDENCY
+ # https://derflounder.wordpress.com/2012/11/20/clearing-the-quarantine-extended-attribute-from-downloaded-applications/
+ find $ANDROID_NDK_PATH -name "$DEPENDENCY" -type f | xargs sudo xattr -r -d com.apple.quarantine
+done


### PR DESCRIPTION
MacOS Catalina complains about security permissions, when trying to build the tool chain. This happens because we download the Android NDK and the build script invokes executables from the NDK.

MacOS Catalina considers these _insecure_ as these binaries are downloaded from the internet and pops up an alert each time a library is used.

Running the script `fixCatalinaPermissions.sh` resolves this issue by tagging each of these dependencies to be _secure_