### PR TITLE
Fix permissions for dependency 'llvm-strip' + add architecture 'armeabi-v7a '

### DIFF
--- a/fixCatalinaPermissions.sh
+++ b/fixCatalinaPermissions.sh
@@ -4,10 +4,10 @@
 ## due to executing libs from the NDK that we downloaded during setup.
 
 # common dependencies
-DEPENDENCIES=(clang clang++ as ld ld.gold *.dylib)
+DEPENDENCIES=(clang clang++ as ld ld.gold *.dylib llvm-strip)
 
 # for each architecture
-for ARCHITECTURE in arm-linux-androideabi aarch64-linux-android x86_64-linux-android;
+for ARCHITECTURE in armeabi-v7a arm-linux-androideabi aarch64-linux-android x86_64-linux-android;
 do
     for ARCH_DEPENDENCY in ranlib ar strip;
     do


### PR DESCRIPTION
While setting up the toolchain on my machine recently, I got the permission issue for `llvm-strip`, which the current script doesn't fix.

Also this now allows building for `armeabi-v7a` which we don't really use but I don't see a harm in adding it.