### PR TITLE
update swift toolchain to 5.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Check out [getting-started](https://github.com/flowkey/UIKit-cross-platform/tree
 ANDROID_ABI="armeabi-v7a" CMAKE_BUILD_TYPE="Debug" swift-build.sh
 ```
 
-#### For users on MacOS Catalina (10.15.x)
+#### MacOS file permissions
 
-Since use a downloaded version of the Android NDK in this build, MacOS Catalina complains about security issues. Running the build might show you alerts for every library from the NDK that is invoked by the build script, asking to grant permissions.
+Since we use downloaded versions of the swift toolchain and Android NDK in this build, MacOS complains about potential security issues. Running the build might show you alerts for every binarythat is invoked by the build script, asking to manually grant permissions.
 
-Running the [`fixCatalinaPermissions.sh`](fixCatalinaPermissions.sh) script, after setup, but before invoking the build, should resolve this issue.
+Running the [`fixMacOSPermissions.sh`](fixMacOSPermissions.sh) script, after setup, but before invoking the build, should resolve this issue.
 
 ## Credits
 

--- a/fixMacOSPermissions.sh
+++ b/fixMacOSPermissions.sh
@@ -4,20 +4,23 @@
 ## due to executing libs from the NDK that we downloaded during setup.
 
 # common dependencies
-DEPENDENCIES=(clang clang++ as ld ld.gold *.dylib llvm-strip)
+NDK_DEPENDENCIES=(clang clang++ as ld ld.gold *.dylib llvm-strip)
 
 # for each architecture
 for ARCHITECTURE in armeabi-v7a arm-linux-androideabi aarch64-linux-android x86_64-linux-android;
 do
     for ARCH_DEPENDENCY in ranlib ar strip;
     do
-        DEPENDENCIES+=( $ARCHITECTURE-$ARCH_DEPENDENCY )
+        NDK_DEPENDENCIES+=( $ARCHITECTURE-$ARCH_DEPENDENCY )
     done
 done
 
-for DEPENDENCY in ${DEPENDENCIES[@]};
+for NDK_DEPENDENCY in ${NDK_DEPENDENCIES[@]};
 do
- echo $DEPENDENCY
+ echo $NDK_DEPENDENCY
  # https://derflounder.wordpress.com/2012/11/20/clearing-the-quarantine-extended-attribute-from-downloaded-applications/
  find $ANDROID_NDK_PATH -name "$DEPENDENCY" -type f | xargs sudo xattr -r -d com.apple.quarantine
 done
+
+echo swift-frontend
+sudo xattr -r -d com.apple.quarantine ./swift-android.xctoolchain/usr/bin/swift-frontend

--- a/setup.sh
+++ b/setup.sh
@@ -23,8 +23,8 @@ downloadToolchain() {
 
     log "Downloading Toolchain..."
 
-    # mirror of https://github.com/vgorloff/swift-everywhere-toolchain/releases/tag/1.0.71
-    TOOLCHAIN_PATH="https://swift-toolchain-artifacts.flowkeycdn.com/swift-android-5.4.2.tar.gz"
+    # mirror of https://github.com/vgorloff/swift-everywhere-toolchain/releases/tag/1.0.78
+    TOOLCHAIN_PATH="https://swift-toolchain-artifacts.flowkeycdn.com/swift-android-5.5.2.tar.gz"
 
     curl -LO $TOOLCHAIN_PATH
     log "Extracting Toolchain..."


### PR DESCRIPTION
based on https://github.com/vgorloff/swift-everywhere-toolchain/releases/tag/1.0.78