### PR TITLE
fix build when xcode 13.3 command line tools are installed

### DIFF
--- a/swift-build.sh
+++ b/swift-build.sh
@@ -17,6 +17,9 @@ then
 fi
 
 
+# prioritize NDKs clang over from /usr/bin/clang
+export PATH="/Users/michaelknoch/Library/Android/sdk/ndk/21.4.7075529/toolchains/llvm/prebuilt/darwin-x86_64/bin:$PATH"
+
 configure() {
     echo "Configure ${CMAKE_BUILD_TYPE} for ${ANDROID_ABI}"
 

--- a/swift-build.sh
+++ b/swift-build.sh
@@ -17,7 +17,8 @@ then
 fi
 
 
-# prioritize NDKs clang over xcode clang from /usr/bin/
+# Ensure clang from ndk is used when invoking `clang` without specific path.
+# Otherwise it executes `/usr/bin/clang` which references clang from xcode command line tools.
 export PATH="$ANDROID_NDK_PATH/toolchains/llvm/prebuilt/darwin-x86_64/bin:$PATH"
 
 configure() {

--- a/swift-build.sh
+++ b/swift-build.sh
@@ -17,8 +17,8 @@ then
 fi
 
 
-# prioritize NDKs clang over from /usr/bin/clang
-export PATH="/Users/michaelknoch/Library/Android/sdk/ndk/21.4.7075529/toolchains/llvm/prebuilt/darwin-x86_64/bin:$PATH"
+# prioritize NDKs clang over xcode clang from /usr/bin/
+export PATH="$ANDROID_NDK_PATH/toolchains/llvm/prebuilt/darwin-x86_64/bin:$PATH"
 
 configure() {
     echo "Configure ${CMAKE_BUILD_TYPE} for ${ANDROID_ABI}"


### PR DESCRIPTION
Using `clang` from ndk fixes a linking issue which occurs when updating xcode to 13.3

```
/usr/local/ndk/21.4.7075529/toolchains/llvm/prebuilt/darwin-x86_64/lib/gcc/arm-linux-androideabi/4.9.x/../../../../arm-linux-androideabi/bin/ld.gold: error: cannot open /Applications/Xcode 13.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/lib/linux/libclang_rt.builtins-arm-android.a: No such file or directory
/usr/local/ndk/21.4.7075529/toolchains/llvm/prebuilt/darwin-x86_64/lib/gcc/arm-linux-androideabi/4.9.x/../../../../arm-linux-androideabi/bin/ld.gold: error: cannot open /Applications/Xcode 13.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/lib/linux/libclang_rt.builtins-arm-android.a: No such file or directory
clang: error: linker command failed with exit code 1 (use -v to see invocation)
<unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
[105/449] Building C object UIKit/SDL/SDL2/CMakeFiles/SDL.dir/src/video/SDL_blit_auto.c.o
[106/449] Building C object UIKit/SDL/sdl-gpu/CMakeFiles/SDL_gpu.dir/renderer_GLES_3.c.o
[107/449] Building C object UIKit/SDL/SDL2/CMakeFiles/SDL.dir/src/audio/SDL_audiotypecvt.c.o
ninja: build stopped: subcommand failed.
```