### PR TITLE
fix setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,6 +11,8 @@ then
     ANDROID_ABI=arm64-v8a
 fi
 
+: "${SCRIPT_ROOT:=$(cd "$(dirname "$0")"; pwd -P)}"
+
 readonly SDK_DIR="${SCRIPT_ROOT}/sdk"
 readonly TOOLCHAIN_PATH="${TOOLCHAIN_PATH:-/Library/Developer/Toolchains/swift-5.7-RELEASE.xctoolchain}"
 


### PR DESCRIPTION
Currently setting up the toolchain fails with:

```
(base) ➜  swift-android-toolchain git:(master) ✗ ./setup.sh --clean
ANDROID_ABI not set. Defaulting to 'arm64-v8a'
[swift-android-toolchain] Let's start from scratch...
mkdir: /sdk: Read-only file system
./setup.sh: line 85: pushd: /sdk: No such file or directory
[swift-android-toolchain] Downloading arm64-v8a SDK...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 44.8M  100 44.8M    0     0  9007k      0  0:00:05  0:00:05 --:--:-- 10.3M
[swift-android-toolchain] Downloading armeabi-v7a SDK...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 45.9M  100 45.9M    0     0  8489k      0  0:00:05  0:00:05 --:--:-- 9715k
[swift-android-toolchain] Downloading x86_64 SDK...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 46.1M  100 46.1M    0     0  8823k      0  0:00:05  0:00:05 --:--:-- 10.0M
./setup.sh: line 111: popd: directory stack empty
ln: /sdk/arm64-v8a/usr/lib/swift/clang: No such file or directory
ln: /sdk/arm64-v8a/usr/lib/swift_static/clang: No such file or directory
```

because SCRIPT_ROOT is not defined. This PR fixes this.